### PR TITLE
Use new web socket library

### DIFF
--- a/LCUSharp/LCUSharp.csproj
+++ b/LCUSharp/LCUSharp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/LCUSharp/LCUSharp.csproj
+++ b/LCUSharp/LCUSharp.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
-    <PackageReference Include="websocketsharp.core" Version="1.0.0" />
+    <PackageReference Include="Websocket.Client" Version="4.3.30" />
   </ItemGroup>
 
 </Project>

--- a/LCUSharp/LCUSharp.csproj
+++ b/LCUSharp/LCUSharp.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Websocket.Client" Version="4.3.30" />
   </ItemGroup>
 

--- a/LCUSharp/Utility/LeagueProcessHandler.cs
+++ b/LCUSharp/Utility/LeagueProcessHandler.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
 using System.IO;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace LCUSharp.Utility
@@ -14,9 +13,9 @@ namespace LCUSharp.Utility
         private const string ProcessName = "LeagueClientUx";
 
         /// <summary>
-        /// Triggers when the league client is exited.
+        /// Triggers when the league client is closed.
         /// </summary>
-        public event EventHandler Exited;
+        public event EventHandler Closed;
 
         /// <summary>
         /// The league client's process.
@@ -32,7 +31,7 @@ namespace LCUSharp.Utility
         /// Waits for the league client's process to start.
         /// </summary>
         /// <returns>True if the process was found successfully, otherwise false.</returns>
-        public bool WaitForProcess()
+        public async Task<bool> WaitForProcessAsync()
         {
             while (true)
             {
@@ -40,7 +39,9 @@ namespace LCUSharp.Utility
                 if (processes.Length > 0)
                 {
                     if (Process != null)
+                    {
                         Process.Exited -= OnProcessExited;
+                    }
 
                     Process = processes[0];
                     Process.EnableRaisingEvents = true;
@@ -50,20 +51,20 @@ namespace LCUSharp.Utility
                     break;
                 }
 
-                Thread.Sleep(100);
+                await Task.Delay(100).ConfigureAwait(false);
             }
 
             return true;
         }
 
         /// <summary>
-        /// Called when the league client is exited.
+        /// Called when the league client is closed.
         /// </summary>
         /// <param name="sender">The sender.</param>
         /// <param name="e">The event arguments.</param>
         private void OnProcessExited(object sender, EventArgs e)
         {
-            Exited?.Invoke(sender, e);
+            Closed?.Invoke(sender, e);
         }
     }
 }

--- a/LCUSharp/Utility/LockFileHandler.cs
+++ b/LCUSharp/Utility/LockFileHandler.cs
@@ -50,7 +50,9 @@ namespace LCUSharp.Utility
         {
             var filePath = Path.Combine(path, FileName);
             if (File.Exists(filePath))
+            {
                 return filePath;
+            }
 
             var fileCreated = new TaskCompletionSource<bool>();
             var fileWatcher = new FileSystemWatcher(path);

--- a/LCUSharp/Utility/LockFileHandler.cs
+++ b/LCUSharp/Utility/LockFileHandler.cs
@@ -29,7 +29,7 @@ namespace LCUSharp.Utility
             {
                 using (var reader = new StreamReader(fileStream))
                 {
-                    var contents = await reader.ReadToEndAsync();
+                    var contents = await reader.ReadToEndAsync().ConfigureAwait(false);
                     var items = contents.Split(':');
 
                     var processId = int.Parse(items[1]);
@@ -70,7 +70,7 @@ namespace LCUSharp.Utility
             fileWatcher.Created += OnFileCreated;
             fileWatcher.EnableRaisingEvents = true;
 
-            await fileCreated.Task;
+            await fileCreated.Task.ConfigureAwait(false);
             return filePath;
         }
     }

--- a/LCUSharp/Websocket/ILeagueEventHandler.cs
+++ b/LCUSharp/Websocket/ILeagueEventHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 
 namespace LCUSharp.Websocket
 {
@@ -20,12 +21,12 @@ namespace LCUSharp.Websocket
         /// <summary>
         /// Connects to the WebSocket server.
         /// </summary>
-        void Connect();
+        Task ConnectAsync();
 
         /// <summary>
         /// Disconnects from the WebSocket server.
         /// </summary>
-        void Disconnect();
+        Task<bool> DisconnectAsync();
 
         /// <summary>
         /// Initializes the web socket listener.
@@ -45,7 +46,8 @@ namespace LCUSharp.Websocket
         /// Unsubscribes the event handlers subscribed to the specified event uri.
         /// </summary>
         /// <param name="uri">The uri to unsubscribe from.</param>
-        void Unsubscribe(string uri);
+        /// <returns>True if the uri exists and was unsubscribed successfully, otherwise false.</returns>
+        bool Unsubscribe(string uri);
 
         /// <summary>
         /// Unsubcribes all event handlers.

--- a/LCUSharp/Websocket/LeagueEventHandler.cs
+++ b/LCUSharp/Websocket/LeagueEventHandler.cs
@@ -1,8 +1,11 @@
 ﻿using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
-using System.Security.Authentication;
-using WebSocketSharp;
+using System.Net;
+using System.Net.WebSockets;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using Websocket.Client;
 
 namespace LCUSharp.Websocket
 {
@@ -18,9 +21,9 @@ namespace LCUSharp.Websocket
         private readonly Dictionary<string, List<EventHandler<LeagueEvent>>> _subscribers;
 
         /// <summary>
-        /// Websocket used to connect to the League Client's backend.
+        /// Websocket client used to connect to the League Client's backend.
         /// </summary>
-        private WebSocket _webSocket;
+        private WebsocketClient _webSocket;
 
         /// <inheritdoc />
         public EventHandler<LeagueEvent> MessageReceived { get; set; }
@@ -40,88 +43,88 @@ namespace LCUSharp.Websocket
         }
 
         /// <inheritdoc />
-        public void Connect()
+        public async Task ConnectAsync()
         {
-            _webSocket.Connect();
-            _webSocket.Send("[5, \"OnJsonApiEvent\"]");
+            await _webSocket.Start();
+            await _webSocket.SendInstant("[5, \"OnJsonApiEvent\"]");
         }
 
         /// <inheritdoc />
-        public void Disconnect()
+        public async Task<bool> DisconnectAsync()
         {
-            _webSocket.Close();
+            return await _webSocket.Stop(WebSocketCloseStatus.NormalClosure,
+                "User requested to close the connection.");
         }
 
         /// <inheritdoc />
         public void ChangeSettings(int port, string token)
         {
-            _webSocket = new WebSocket($"wss://127.0.0.1:{port}/", "wamp");
-            _webSocket.SetCredentials("riot", token, true);
-            _webSocket.SslConfiguration.EnabledSslProtocols = SslProtocols.Tls12;
-            _webSocket.SslConfiguration.ServerCertificateValidationCallback = (response, cert, chain, errors) => true;
+            _webSocket = new WebsocketClient(new Uri($"wss://127.0.0.1:{port}/"), () =>
+            {
+                var socket = new ClientWebSocket
+                {
+                    Options =
+                    {
+                        Credentials = new NetworkCredential("riot", token),
+                        RemoteCertificateValidationCallback =
+                            (sender, cert, chain, sslPolicyErrors) => true,
+                    }
+                };
 
-            _webSocket.OnError += OnError;
-            _webSocket.OnMessage += OnMessage;
+                socket.Options.AddSubProtocol("wamp");
+                return socket;
+            });
+
+            _webSocket
+                .MessageReceived
+                .Where(msg => msg.Text != null)
+                .Where(msg => msg.Text.StartsWith('['))
+                .Subscribe(msg =>
+                {
+                    // Check if the message is json received from the client
+                    var eventArray = JArray.Parse(msg.Text);
+                    var eventNumber = eventArray?[0].ToObject<int>();
+
+                    if (eventNumber != ClientEventNumber)
+                    {
+                        return;
+                    }
+
+                    var leagueEvent = eventArray[ClientEventData].ToObject<LeagueEvent>();
+                    MessageReceived?.Invoke(this, leagueEvent);
+
+                    if (!_subscribers.TryGetValue(leagueEvent.Uri, out var eventHandlers))
+                    {
+                        return;
+                    }
+
+                    eventHandlers.ForEach(eventHandler => eventHandler?.Invoke(this, leagueEvent));
+                });
         }
 
         /// <inheritdoc />
         public void Subscribe(string uri, EventHandler<LeagueEvent> eventHandler)
         {
-            if (_subscribers.TryGetValue(uri, out List<EventHandler<LeagueEvent>> eventHandlers))
+            if (_subscribers.TryGetValue(uri, out var eventHandlers))
+            {
                 eventHandlers.Add(eventHandler);
+            }
             else
+            {
                 _subscribers.Add(uri, new List<EventHandler<LeagueEvent>> { eventHandler });
+            }
         }
 
         /// <inheritdoc />
-        public void Unsubscribe(string uri)
+        public bool Unsubscribe(string uri)
         {
-            if (_subscribers.ContainsKey(uri))
-                _subscribers.Remove(uri);
+            return _subscribers.Remove(uri);
         }
 
         /// <inheritdoc />
         public void UnsubscribeAll()
         {
             _subscribers.Clear();
-        }
-
-        /// <summary>
-        /// Called when an error is received from the client.
-        /// </summary>
-        /// <param name="sender">The sender.</param>
-        /// <param name="e">The error arguments.</param>
-        private void OnError(object sender, ErrorEventArgs e)
-        {
-            ErrorReceived?.Invoke(sender, e.Message);
-        }
-
-        /// <summary>
-        /// Called when a message is received from the client.
-        /// </summary>
-        /// <param name="sender">The sender.</param>
-        /// <param name="e">The message arguments.</param>
-        private void OnMessage(object sender, MessageEventArgs e)
-        {
-            // Check if the message is json received from the client
-            if (e.IsText)
-            {
-                var eventArray = JArray.Parse(e.Data);
-                var eventNumber = eventArray[0].ToObject<int>();
-
-                if (eventNumber == ClientEventNumber)
-                {
-                    var leagueEvent = eventArray[ClientEventData].ToObject<LeagueEvent>();
-                    MessageReceived?.Invoke(sender, leagueEvent);
-
-                    // Call subscribers
-                    if (_subscribers.TryGetValue(leagueEvent.Uri, out List<EventHandler<LeagueEvent>> eventHandlers))
-                    {
-                        foreach (var eventHandler in eventHandlers)
-                            eventHandler?.Invoke(sender, leagueEvent);
-                    }
-                }
-            }
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -55,14 +55,30 @@ private void OnGameFlowChanged(object sender, LeagueEvent e)
     var result = e.Data.ToString();
     var state = string.Empty;
 
-    if (result == "None")
-        state = "main menu";
-    else if (result == "ChampSelect")
-        state = "champ select";
-    else if (result == "Lobby")
-        state = "lobby";
-    else if (result == "InProgress")
-        state = "game";
+    switch (result)
+    {
+        case "None":
+            state = "main menu";
+            break;
+        case "Lobby":
+            state = "lobby";
+            break;
+        case "ChampSelect":
+            state = "champ select";
+            break;
+        case "GameStart":
+            state = "game started";
+            break;
+        case "InProgress":
+            state = "game";
+            break;
+        case "WaitingForStats":
+            state = "waiting for stats";
+            break;
+        default:
+            state = $"unknown state: {result}";
+            break;
+    }
 
     // Print new state and set work to complete.
     Console.WriteLine($"Status update: Entered {state}.");


### PR DESCRIPTION
Uses a new web socket library which also fixes #16. This introduces a breaking change which makes the library target .NET Standard 2.1 instead of 2.0. This means that .NET Framework is no longer supported. For more information, please refer to this chart: https://docs.microsoft.com/en-us/dotnet/standard/net-standard